### PR TITLE
🐛 Use `extras` as `features` in `hatch` envs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,9 @@ tests = [
 ]
 
 [tool.hatch.envs.quality]
-dependencies = [
-  "REPLACE_PACKAGE_NAME[quality]"
+features = [
+  "quality",
 ]
-detached = true
 
 [tool.hatch.envs.quality.scripts]
 check = [
@@ -61,7 +60,9 @@ format = [
 ]
 
 [tool.hatch.envs.test]
-dependencies = ["REPLACE_PACKAGE_NAME[tests]"]
+features = [
+  "tests",
+]
 
 [tool.hatch.envs.test.scripts]
 run = "pytest tests/ --durations 0 -s"


### PR DESCRIPTION
## 🐛 Bug Fixes

- Use `extras` as `features` in `hatch` envs

## 🔗 Linked Discussion

https://github.com/pypa/hatch/discussions/662