### PR TITLE
improve ci + add coverage

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -16,6 +16,10 @@ on:
     types:
       - published
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-quality:
     runs-on: ubuntu-latest
@@ -38,6 +42,7 @@ jobs:
         run: |
           black --check --diff --preview src tests
           ruff src tests
+          mypy src
 
   run-tests:
     needs: check-quality
@@ -59,7 +64,7 @@ jobs:
           pip install ".[tests]"
 
       - name: run-tests
-        run: pytest tests/ -s --durations 0
+        run: pytest --cov=REPLACE_PACKAGE_NAME --cov-report=term-missing tests/ -s --durations 0
 
   deploy-docs:
     needs: run-tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ quality = [
 ]
 tests = [
   "pytest~=7.1.2",
+  "pytest-cov~=4.1",
 ]
 
 [tool.hatch.envs.quality]
@@ -104,7 +105,7 @@ features = [
 ]
 
 [tool.hatch.envs.tests.scripts]
-run = "pytest tests/ --durations 0 -s"
+run = "pytest --cov=REPLACE_PACKAGE_NAME --cov-report=term-missing tests/ --durations 0 -s"
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["38", "39", "310", "311"]


### PR DESCRIPTION
This PR:

* Adds `mypy` checks to the ci (`check-quality` job)
* Adds a concurrency key to automatically stop previous actions if multiple commits are made.
* Adds coverage as a helper. No target score could block CI or release. People can add it themselves if they require a precise target score.