### PR TITLE
Add extra args to pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ features = [
 ]
 
 [tool.hatch.envs.tests.scripts]
-run = "pytest --cov=REPLACE_PACKAGE_NAME --cov-report=term-missing tests/ --durations 0 -s"
+run = "pytest --cov=REPLACE_PACKAGE_NAME --cov-report=term-missing tests/ --durations 0 -s {args:tests}"
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["38", "39", "310", "311"]


### PR DESCRIPTION
## ✨ Features

This tiny PR adds the possibility for the user to add extra arguments when running the `tests` command.

For example:
- Adding a lot more details: `hatch run tests:run -vv`
- Testing only one function or one module: `hatch run tests:run -k test_my_function`